### PR TITLE
feat(homepage): rebuild heystax marketing page (#583)

### DIFF
--- a/docs/contracts/feature_architecture.yml
+++ b/docs/contracts/feature_architecture.yml
@@ -74,9 +74,8 @@ rules:
           - pattern: /dash\.heystax\.ai\/onboarding\?source=homepage/
             message: "Primary signup CTA must link to Dash onboarding for #583"
             scope:
-              - "src/components/Hero.tsx"
-              - "src/components/Pricing.tsx"
-              - "src/components/FinalCTA.tsx"
+              - "src/app/page.tsx"
+              - "src/app/pricing/page.tsx"
 
     - id: ARCH-004
       title: "Images must use unoptimized mode or plain img tags"

--- a/docs/contracts/feature_no_payment_signup_583.yml
+++ b/docs/contracts/feature_no_payment_signup_583.yml
@@ -1,37 +1,46 @@
 contract_meta:
   id: feature_no_payment_signup_583
-  version: 1
-  created_from_spec: "Hulupeep/tabstax#583"
+  version: 2
+  created_from_spec: "Hulupeep/tabstax#583 homepage rebuild"
   owner: "tabstax-web"
 
 rules:
   non_negotiable:
     - id: WEB-NPS-001
-      title: "Website start CTAs route to Dash onboarding"
-      requirement: "Homepage Start Now CTAs must link to https://dash.heystax.ai/onboarding?source=homepage, not the dashboard body or Stripe checkout."
+      title: "Homepage has one primary start CTA above the fold"
+      requirement: "The rendered homepage hero has exactly one Start Now CTA and it routes to Dash onboarding."
       scope:
-        - "src/components/Header.tsx"
-        - "src/components/Hero.tsx"
-        - "src/components/Pricing.tsx"
-        - "src/components/FinalCTA.tsx"
+        - "src/app/page.tsx"
 
     - id: WEB-NPS-002
-      title: "Pricing is plan intent, not checkout"
-      requirement: "Pricing presents Principal, Team, and Enterprise as setup intent and must not expose old Free/Pro checkout copy."
+      title: "Homepage does not sell pricing inline"
+      requirement: "The homepage must not display prices, Free/Pro tiers, or checkout/payment copy. Pricing lives at /pricing."
       scope:
-        - "src/components/Pricing.tsx"
+        - "src/app/page.tsx"
+        - "src/app/pricing/page.tsx"
 
     - id: WEB-NPS-003
-      title: "No payment collection on first start"
-      requirement: "Website copy must not ask for a card, embed Stripe checkout, or imply payment before account entry."
+      title: "Homepage proof mock replaces the old video"
+      requirement: "The homepage must not render the YouTube product embed. It must render the Done/Next proof rows from the rebuild spec."
       scope:
-        - "src/components/Hero.tsx"
-        - "src/components/Pricing.tsx"
-        - "src/components/FinalCTA.tsx"
+        - "src/app/page.tsx"
+
+    - id: WEB-NPS-004
+      title: "Navigation is narrowed"
+      requirement: "The header must render only Product, Blog, and Sign in links next to the logo. Sign in is a text link."
+      scope:
+        - "src/components/Header.tsx"
+
+    - id: WEB-NPS-005
+      title: "Homepage metadata matches the rebuild"
+      requirement: "Page title and description must match the homepage rebuild copy."
+      scope:
+        - "src/app/layout.tsx"
 
 acceptance:
   - "Hero Start Now opens Dash onboarding with source=homepage."
-  - "Header Start Now opens Dash onboarding with source=homepage."
-  - "Pricing renders Principal, Team, and Enterprise."
-  - "Pricing does not render legacy Free/Pro €3.99 checkout positioning."
-  - "Final CTA opens Dash onboarding with source=homepage."
+  - "Homepage has no price copy and no YouTube iframe."
+  - "Proof mock shows Done rows, Next rows, and the Yours tag."
+  - "Technical section contains the CLI code block and no technical heading."
+  - "Close section uses Apply, not Start Now."
+  - "Footer links include Pricing, but homepage does not render pricing."

--- a/src/__tests__/contracts/no_payment_signup_583_contract.test.ts
+++ b/src/__tests__/contracts/no_payment_signup_583_contract.test.ts
@@ -9,59 +9,62 @@ function readSrc(relPath: string) {
 }
 
 describe("Contract: feature_no_payment_signup_583", () => {
-  it("routes primary homepage CTAs to Dash onboarding", () => {
-    const files = [
-      "components/Header.tsx",
-      "components/Hero.tsx",
-      "components/Pricing.tsx",
-      "components/FinalCTA.tsx",
-    ];
+  it("keeps the homepage start CTA on Dash onboarding", () => {
+    const page = readSrc("app/page.tsx");
 
-    files.forEach((file) => {
-      expect(readSrc(file)).toContain("DASH_ONBOARDING_URL");
-    });
+    expect(page).toContain("DASH_ONBOARDING_URL");
     expect(readSrc("lib/routes.ts")).toContain(onboardingUrl);
+    expect(page).toContain("Start Now");
   });
 
-  it("does not route Start Now to the dashboard body", () => {
-    const files = [
-      "components/Header.tsx",
-      "components/Hero.tsx",
-      "components/Pricing.tsx",
-      "components/FinalCTA.tsx",
-    ];
+  it("narrows the header to Product, Blog, and Sign in", () => {
+    const header = readSrc("components/Header.tsx");
 
-    files.forEach((file) => {
-      expect(readSrc(file)).not.toMatch(/https:\/\/dash\.heystax\.ai\/attention/);
-    });
+    expect(header).toContain('label: "Product"');
+    expect(header).toContain('label: "Blog"');
+    expect(header).toContain('label: "Sign in"');
+    expect(header).not.toContain('label: "Individuals"');
+    expect(header).not.toContain('label: "Teams"');
+    expect(header).not.toContain('label: "Use Cases"');
+    expect(header).not.toContain("Start Now");
   });
 
-  it("renders the #583 plan intent tiers", () => {
-    const pricing = readSrc("components/Pricing.tsx");
+  it("removes homepage pricing and payment-first copy", () => {
+    const page = readSrc("app/page.tsx");
 
-    expect(pricing).toContain("Principal");
-    expect(pricing).toContain("Team");
-    expect(pricing).toContain("Enterprise");
-    expect(pricing).toContain("Plan selection is intent, not checkout.");
+    expect(page).not.toMatch(/\$\d+|€\d+|â‚¬\d+/);
+    expect(page).not.toMatch(/\bFree\b/);
+    expect(page).not.toContain("Free and Pro");
+    expect(page).not.toContain("Pro tier");
+    expect(page).not.toMatch(/card number|cvv|expiry|stripe checkout/i);
+    expect(page).not.toContain("Simple pricing");
   });
 
-  it("removes legacy payment-first pricing copy", () => {
-    const pricing = readSrc("components/Pricing.tsx");
+  it("replaces the video with the Done and Next proof mock", () => {
+    const page = readSrc("app/page.tsx");
 
-    expect(pricing).not.toMatch(/\bFree\b/);
-    expect(pricing).not.toMatch(/\bPro\b/);
-    expect(pricing).not.toContain("€3.99");
-    expect(pricing).not.toContain("7-day free trial");
+    expect(page).not.toMatch(/iframe|youtube|youtube-nocookie/i);
+    expect(page).toContain("Done while you slept. Decisions when you arrive.");
+    expect(page).toContain("@scribe drafted reply to solicitor");
+    expect(page).toContain("@notify sent Sprint 7 update to John");
+    expect(page).toContain("Approve scribe's draft to solicitor");
+    expect(page).toContain('tag: "Yours"');
   });
 
-  it("does not collect payment on first start", () => {
-    const pageCopy = [
-      readSrc("components/Hero.tsx"),
-      readSrc("components/Pricing.tsx"),
-      readSrc("components/FinalCTA.tsx"),
-    ].join("\n");
+  it("keeps the technical section as unlabeled product detail", () => {
+    const page = readSrc("app/page.tsx");
 
-    expect(pageCopy).not.toMatch(/card number|cvv|expiry|stripe checkout/i);
-    expect(pageCopy).toContain("No card.");
+    expect(page).toContain('hey "draft update to @rob on Claim Alert sprint"');
+    expect(page).toMatch(/HookTunnel logs every agent action in both\s+directions\./);
+    expect(page).not.toContain(">Technical");
+  });
+
+  it("updates homepage metadata", () => {
+    const layout = readSrc("app/layout.tsx");
+
+    expect(layout).toContain("HeyStax — Hire agents that already know your job.");
+    expect(layout).toContain(
+      "Multiple projects, work and home. Your AI remembers none of them. HeyStax holds all of them."
+    );
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,3 +54,13 @@ body {
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-heading);
 }
+
+.mobile-full-cta {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .mobile-full-cta {
+    width: auto;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,11 +5,11 @@ import { Footer } from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: {
-    default: "HeyStax — Never Pay the Reconstruction Tax Again",
+    default: "HeyStax — Hire agents that already know your job.",
     template: "%s | HeyStax",
   },
   description:
-    "HeyStax is your flow engine for work across AI chat, terminal, browser, and web. Open the exact workspace. See the exact next action. Continue in seconds.",
+    "Multiple projects, work and home. Your AI remembers none of them. HeyStax holds all of them.",
   metadataBase: new URL("https://heystax.ai"),
   icons: {
     icon: [
@@ -19,9 +19,9 @@ export const metadata: Metadata = {
     apple: "/apple-touch-icon.png",
   },
   openGraph: {
-    title: "HeyStax — Never Pay the Reconstruction Tax Again",
+    title: "HeyStax — Hire agents that already know your job.",
     description:
-      "Your flow engine for work across AI chat, terminal, browser, and web. Open the exact workspace. See the exact next action. Continue in seconds.",
+      "Multiple projects, work and home. Your AI remembers none of them. HeyStax holds all of them.",
     type: "website",
     url: "https://heystax.ai",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,33 +1,266 @@
-import { Hero } from "@/components/Hero";
-import { PainStrip } from "@/components/PainStrip";
-import { IndividualValue } from "@/components/IndividualValue";
-import { StaxModel } from "@/components/StaxModel";
-import { WorksEverywhere } from "@/components/WorksEverywhere";
-import { FastKickoff } from "@/components/FastKickoff";
-import { MotionLayer } from "@/components/MotionLayer";
-import { AudienceSplit } from "@/components/AudienceSplit";
-import { VideoSection } from "@/components/VideoSection";
-import { QuickStart } from "@/components/QuickStart";
-import { UseCaseTeaser } from "@/components/UseCaseTeaser";
-import { Pricing } from "@/components/Pricing";
-import { FinalCTA } from "@/components/FinalCTA";
+import { DASH_ONBOARDING_URL } from "@/lib/routes";
+
+const doneRows = [
+  {
+    project: "Cave Airbnb",
+    action: "@scribe drafted reply to solicitor",
+    time: "9:14am",
+  },
+  {
+    project: "Claim Alert",
+    action: "@notify sent Sprint 7 update to John",
+    time: "9:42am",
+  },
+];
+
+const nextRows = [
+  {
+    priority: "Must",
+    project: "HeyStax",
+    action: "Lock SKU naming decision",
+  },
+  {
+    priority: "Must",
+    project: "Cave Airbnb",
+    action: "Approve scribe's draft to solicitor",
+    tag: "Yours",
+  },
+  {
+    priority: "Must",
+    project: "Obrayo",
+    action: "Confirm Portugal pilot scope",
+  },
+  {
+    priority: "Should",
+    project: "Household",
+    action: "Renew NCT for the Volvo",
+  },
+  {
+    priority: "Should",
+    project: "HeyStax",
+    action: "Rewrite homepage hero copy",
+  },
+];
+
+const capabilityCards = [
+  {
+    number: "01",
+    title: "Typed work graph",
+    body: "Every project is a Stax with goals, dates, people, and next actions. Humans and agents share the same data model.",
+  },
+  {
+    number: "02",
+    title: "Cross-surface motion",
+    body: "Used inside Claude, your terminal, your browser, and the web. One graph, every surface.",
+  },
+  {
+    number: "03",
+    title: "Agents as peers",
+    body: "@handle works the same for a person or an agent. Same audit log, same assignment, same room.",
+  },
+];
+
+function PriorityPill({ priority }: { priority: string }) {
+  const className =
+    priority === "Must"
+      ? "bg-red-100 text-red-800"
+      : "bg-amber-light text-amber";
+
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${className}`}>
+      {priority}
+    </span>
+  );
+}
 
 export default function Home() {
   return (
     <>
-      <Hero />
-      <PainStrip />
-      <IndividualValue />
-      <StaxModel />
-      <WorksEverywhere />
-      <FastKickoff />
-      <MotionLayer />
-      <AudienceSplit />
-      <VideoSection />
-      <QuickStart />
-      <UseCaseTeaser />
-      <Pricing />
-      <FinalCTA />
+      <section
+        id="hero"
+        className="relative overflow-hidden bg-cream py-24 md:py-32"
+      >
+        <div className="absolute inset-x-0 bottom-0 h-56 bg-[radial-gradient(ellipse_at_bottom,rgba(217,119,6,0.13),transparent_66%)]" />
+        <div className="relative z-10 mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
+          <p className="text-sm text-warm-gray">
+            For you, your team, and your agents.
+          </p>
+          <h1 className="mt-6 font-heading text-5xl font-black leading-tight text-charcoal md:text-7xl">
+            Hire agents that already know your job.
+          </h1>
+          <p className="mx-auto mt-8 max-w-2xl text-lg leading-relaxed text-warm-gray md:text-xl">
+            Multiple projects, work and home. Your AI remembers none of them.
+            HeyStax: All of them.
+          </p>
+          <p className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-warm-gray">
+            HeyStax is the knowledge graph you own. Agents are peers coordinating
+            your next move with you and your team. They know your projects, your
+            goals, your history. They email, follow up, and build. You always know
+            the next right thing to do.
+          </p>
+          <p className="mt-6 text-sm text-warm-gray/70">
+            Used inside Claude, your terminal, your browser, and the web.
+          </p>
+          <a
+            href={DASH_ONBOARDING_URL}
+            className="mobile-full-cta mt-10 inline-flex items-center justify-center rounded-full bg-amber px-8 py-4 text-lg font-semibold text-white shadow-lg transition-colors hover:bg-terracotta"
+          >
+            Start Now
+          </a>
+        </div>
+      </section>
+
+      <section className="bg-cream px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl space-y-6 text-center text-lg leading-relaxed text-warm-gray">
+          <p>
+            You have eight projects. You are paying attention to two.
+            Reconstructing where the other six are is what status meetings are
+            for. You hold them to compensate for not having a system that knows.
+          </p>
+          <p>
+            HeyStax knows. Agents hold the shape of every project and keep it
+            moving. You return to the decision. Not the search. Not the meeting.
+          </p>
+        </div>
+      </section>
+
+      <section
+        id="product"
+        className="bg-cream px-4 py-20 sm:px-6 lg:px-8"
+      >
+        <div className="mx-auto max-w-5xl">
+          <p className="mb-6 text-center text-sm text-warm-gray">
+            Done while you slept. Decisions when you arrive.
+          </p>
+          <div className="rounded-[2rem] border border-charcoal/10 bg-[#fff7df] p-4 shadow-xl shadow-charcoal/5 sm:p-6">
+            <div className="rounded-[1.5rem] border border-charcoal/10 bg-cream p-4 sm:p-6">
+              <p className="mb-4 text-xs font-semibold tracking-[0.22em] text-warm-gray">
+                Done
+              </p>
+              <div className="space-y-3">
+                {doneRows.map((row) => (
+                  <div
+                    key={`${row.project}-${row.time}`}
+                    className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-2xl bg-white/70 px-3 py-3 text-sm"
+                  >
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+                      <svg
+                        aria-hidden="true"
+                        className="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2.2}
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="m5 12 4 4L19 6"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </span>
+                    <span className="min-w-0">
+                      <span className="mr-2 text-warm-gray">{row.project}</span>
+                      <span className="text-warm-gray/70 line-through">
+                        {row.action}
+                      </span>
+                    </span>
+                    <span className="text-xs text-warm-gray/70">{row.time}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="my-6 border-t border-charcoal/10" />
+
+              <p className="mb-4 text-xs font-semibold tracking-[0.22em] text-warm-gray">
+                Next
+              </p>
+              <div className="space-y-3">
+                {nextRows.map((row) => (
+                  <div
+                    key={`${row.project}-${row.action}`}
+                    className="grid grid-cols-[auto_1fr] items-center gap-3 rounded-2xl bg-white/70 px-3 py-3 text-sm sm:grid-cols-[auto_7rem_1fr_auto]"
+                  >
+                    <PriorityPill priority={row.priority} />
+                    <span className="text-warm-gray sm:order-none">{row.project}</span>
+                    <span className="col-span-2 text-charcoal sm:col-span-1">
+                      {row.action}
+                    </span>
+                    {row.tag ? (
+                      <span className="justify-self-start rounded-full bg-blue-100 px-2.5 py-1 text-[0.68rem] font-semibold text-blue-800 sm:justify-self-end">
+                        {row.tag}
+                      </span>
+                    ) : (
+                      <span className="hidden sm:block" />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cream px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto grid max-w-6xl gap-5 md:grid-cols-3">
+          {capabilityCards.map((card) => (
+            <article
+              key={card.number}
+              className="rounded-[1.5rem] border border-charcoal/10 bg-white/55 p-6 shadow-sm"
+            >
+              <p className="text-sm text-warm-gray">{card.number}</p>
+              <h2 className="mt-8 font-heading text-3xl font-bold text-charcoal">
+                {card.title}
+              </h2>
+              <p className="mt-4 leading-relaxed text-warm-gray">{card.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-t border-charcoal/10 bg-[#fff8e8] px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+          <pre className="overflow-x-auto rounded-[1.5rem] bg-charcoal p-6 text-sm leading-7 text-cream shadow-xl">
+            <code>{`hey "draft update to @rob on Claim Alert sprint"
+hey ls
+hey done 2`}</code>
+          </pre>
+          <div className="space-y-5 text-lg leading-relaxed text-warm-gray">
+            <p>
+              Every action is typed and audited. @handle works the same for a
+              person or an agent. HookTunnel logs every agent action in both
+              directions. The schema: next actions, goals, dates, people,
+              records. Structured fields, not memory blobs. Queryable by any
+              connected agent.
+            </p>
+            <p>
+              MCP-native. Works with Claude, ChatGPT, Cursor, Codex, and any
+              client that speaks MCP.
+            </p>
+          </div>
+        </div>
+        <p className="mx-auto mt-12 max-w-2xl text-center font-heading text-3xl font-bold text-charcoal">
+          Start in Claude. Finish in ChatGPT. Same stax. Same information.
+        </p>
+      </section>
+
+      <section className="border-t border-charcoal/10 bg-cream px-4 py-24 text-center sm:px-6 lg:px-8">
+        <p className="text-sm tracking-[0.22em] text-warm-gray">
+          GYST cohort one
+        </p>
+        <h2 className="mx-auto mt-5 max-w-3xl font-heading text-5xl font-black leading-tight text-charcoal md:text-6xl">
+          Ten operators. By application.
+        </h2>
+        <p className="mx-auto mt-6 max-w-md text-lg leading-relaxed text-warm-gray">
+          Three months free Pro. Personal onboarding. Real work, in real time.
+        </p>
+        <a
+          href={DASH_ONBOARDING_URL}
+          className="mobile-full-cta mt-10 inline-flex items-center justify-center rounded-full bg-amber px-8 py-4 text-lg font-semibold text-white shadow-lg transition-colors hover:bg-terracotta"
+        >
+          Apply
+        </a>
+      </section>
     </>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,23 @@
+import { DASH_ONBOARDING_URL } from "@/lib/routes";
+
+export default function PricingPage() {
+  return (
+    <section className="bg-cream px-4 py-24 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl text-center">
+        <h1 className="font-heading text-5xl font-black leading-tight text-charcoal md:text-6xl">
+          Pricing is moving into the starting flow.
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-warm-gray">
+          Start with the work. Choose the right shape when HeyStax knows what you
+          are setting up.
+        </p>
+        <a
+          href={DASH_ONBOARDING_URL}
+          className="mobile-full-cta mt-10 inline-flex items-center justify-center rounded-full bg-amber px-8 py-4 text-lg font-semibold text-white shadow-lg transition-colors hover:bg-terracotta"
+        >
+          Start Now
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,102 +1,51 @@
 import Link from "next/link";
 
+const footerLinks = [
+  { href: "/#product", label: "Product" },
+  { href: "/blog", label: "Blog" },
+  {
+    href: "https://hulupeep.github.io/TabStax-Help/",
+    label: "Docs",
+    external: true,
+  },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/about", label: "About" },
+  { href: "mailto:hello@heystax.ai", label: "hello@heystax.ai", external: true },
+];
+
 export function Footer() {
   return (
-    <footer className="bg-charcoal text-cream/70">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
-          <div className="md:col-span-2">
-            <p className="font-heading text-xl font-bold text-cream mb-3">
-              HeyStax
-            </p>
-            <p className="text-sm leading-relaxed max-w-md">
-              Pick up where your mind left off.
-            </p>
-          </div>
+    <footer className="border-t border-charcoal/10 bg-cream text-warm-gray">
+      <div className="mx-auto flex max-w-7xl flex-col items-center gap-6 px-4 py-8 text-center text-sm sm:px-6 lg:flex-row lg:justify-between lg:px-8 lg:text-left">
+        <Link href="/" className="font-heading text-xl font-bold text-charcoal">
+          HeyStax
+        </Link>
 
-          <div>
-            <p className="text-sm font-semibold text-cream mb-4">Product</p>
-            <ul className="space-y-2 text-sm">
-              <li>
-                <a
-                  href="https://dash.heystax.ai/attention"
-                  className="hover:text-cream transition-colors"
-                >
-                  Dashboard
-                </a>
-              </li>
-              <li>
-                <Link
-                  href="/hey"
-                  className="hover:text-cream transition-colors"
-                >
-                  Hey CLI
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/use-cases"
-                  className="hover:text-cream transition-colors"
-                >
-                  Use Cases
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/blog"
-                  className="hover:text-cream transition-colors"
-                >
-                  Blog
-                </Link>
-              </li>
-              <li>
-                <a
-                  href="https://hulupeep.github.io/TabStax-Help/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-cream transition-colors"
-                >
-                  Docs
-                </a>
-              </li>
-            </ul>
-          </div>
+        <nav className="flex flex-wrap items-center justify-center gap-x-5 gap-y-3">
+          {footerLinks.map((link) =>
+            link.external ? (
+              <a
+                key={link.href}
+                href={link.href}
+                target={link.href.startsWith("http") ? "_blank" : undefined}
+                rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                className="transition-colors hover:text-charcoal"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="transition-colors hover:text-charcoal"
+              >
+                {link.label}
+              </Link>
+            )
+          )}
+        </nav>
 
-          <div>
-            <p className="text-sm font-semibold text-cream mb-4">Company</p>
-            <ul className="space-y-2 text-sm">
-              <li>
-                <Link
-                  href="/about"
-                  className="hover:text-cream transition-colors"
-                >
-                  About
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/contact"
-                  className="hover:text-cream transition-colors"
-                >
-                  Contact
-                </Link>
-              </li>
-              <li>
-                <a
-                  href="mailto:hello@heystax.ai"
-                  className="hover:text-cream transition-colors"
-                >
-                  hello@heystax.ai
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div className="mt-12 pt-8 border-t border-cream/10 text-center text-xs text-cream/40">
-          &copy; {new Date().getFullYear()} Flout Labs, Ireland. All rights
-          reserved.
-        </div>
+        <p>Flout Labs, Ireland. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,16 +2,11 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { DASH_ONBOARDING_URL } from "@/lib/routes";
 
 const navLinks = [
-  { href: "/#works-everywhere", label: "Product" },
-  { href: "/#individual-value", label: "Individuals" },
-  { href: "/#fast-kickoff", label: "Teams" },
-  { href: "/use-cases", label: "Use Cases" },
+  { href: "/#product", label: "Product" },
   { href: "/blog", label: "Blog" },
-  { href: "/#quick-start", label: "Quick Start" },
-  { href: "https://hulupeep.github.io/TabStax-Help/", label: "Docs", external: true },
+  { href: "https://dash.heystax.ai/attention", label: "Sign in", external: true },
 ];
 
 export function Header() {
@@ -54,12 +49,6 @@ export function Header() {
                 </Link>
               )
             )}
-            <a
-              href={DASH_ONBOARDING_URL}
-              className="inline-flex items-center px-5 py-2.5 rounded-full bg-amber text-white font-semibold text-sm hover:bg-terracotta transition-colors shadow-sm"
-            >
-              Start Now
-            </a>
           </nav>
 
           <button
@@ -118,12 +107,6 @@ export function Header() {
                   </Link>
                 )
               )}
-              <a
-                href={DASH_ONBOARDING_URL}
-                className="mx-4 mt-2 inline-flex items-center justify-center px-5 py-2.5 rounded-full bg-amber text-white font-semibold text-sm hover:bg-terracotta transition-colors"
-              >
-                Start Now
-              </a>
             </nav>
           </div>
         )}

--- a/tests/e2e/journey_homepage_video.spec.ts
+++ b/tests/e2e/journey_homepage_video.spec.ts
@@ -1,44 +1,17 @@
 /**
- * Journey tests: J-HOMEPAGE-VIDEO (CRITICAL)
- * Verifies the YouTube product video is correctly embedded on the homepage.
+ * The homepage rebuild explicitly removes the YouTube embed.
  *
  * Run with: npm run test:e2e tests/e2e/journey_homepage_video.spec.ts
  */
 
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test.describe("J-HOMEPAGE-VIDEO: homepage product video embed", () => {
-  test("video iframe is present on the homepage", async ({ page }) => {
+test.describe("homepage media removal", () => {
+  test("homepage does not render the old YouTube embed", async ({ page }) => {
     await page.goto("/");
-    const iframe = page.locator("iframe").first();
-    await expect(iframe).toBeVisible();
-  });
 
-  test("iframe uses youtube-nocookie.com embed URL", async ({ page }) => {
-    await page.goto("/");
-    const iframeSrc = await page.locator("iframe").first().getAttribute("src");
-    expect(iframeSrc).toContain("youtube-nocookie.com/embed/jcc-PsCdbM8");
-  });
-
-  test("iframe does NOT use youtube.com (privacy check)", async ({ page }) => {
-    await page.goto("/");
-    const iframeSrc = await page.locator("iframe").first().getAttribute("src");
-    expect(iframeSrc).not.toContain("//www.youtube.com/embed");
-  });
-
-  test("iframe has a title attribute for accessibility", async ({ page }) => {
-    await page.goto("/");
-    const iframeTitle = await page.locator("iframe").first().getAttribute("title");
-    expect(iframeTitle).toBeTruthy();
-    expect(iframeTitle!.length).toBeGreaterThan(0);
-  });
-
-  test("video section is visible and not zero-height", async ({ page }) => {
-    await page.goto("/");
-    const iframe = page.locator("iframe").first();
-    const box = await iframe.boundingBox();
-    expect(box).toBeTruthy();
-    expect(box!.width).toBeGreaterThan(200);
-    expect(box!.height).toBeGreaterThan(100);
+    await expect(page.locator("iframe")).toHaveCount(0);
+    await expect(page.getByText("Done while you slept. Decisions when you arrive."))
+      .toBeVisible();
   });
 });

--- a/tests/e2e/journey_no_payment_signup_583.spec.ts
+++ b/tests/e2e/journey_no_payment_signup_583.spec.ts
@@ -1,46 +1,84 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("no-payment signup handoff (#583)", () => {
-  test("homepage start path points to Dash onboarding", async ({ page }) => {
+test.describe("homepage rebuild signup handoff (#583)", () => {
+  test("hero and nav match the rebuilt homepage contract", async ({ page }) => {
     await page.goto("/");
 
-    const heroStart = page.locator("#hero a", { hasText: "Start Now" });
-    await expect(heroStart).toHaveAttribute(
+    await expect(page).toHaveTitle("HeyStax — Hire agents that already know your job.");
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      "content",
+      "Multiple projects, work and home. Your AI remembers none of them. HeyStax holds all of them."
+    );
+
+    await expect(page.getByText("For you, your team, and your agents.")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Hire agents that already know your job." })
+    ).toBeVisible();
+
+    const desktopNav = page.locator("header nav").first();
+    await expect(desktopNav.getByRole("link", { name: "Product" })).toBeVisible();
+    await expect(desktopNav.getByRole("link", { name: "Blog" })).toBeVisible();
+    await expect(desktopNav.getByRole("link", { name: "Sign in" })).toBeVisible();
+    await expect(desktopNav.getByRole("link")).toHaveCount(3);
+
+    const startNow = page.locator("#hero a", { hasText: "Start Now" });
+    await expect(startNow).toHaveCount(1);
+    await expect(startNow).toHaveAttribute(
       "href",
       "https://dash.heystax.ai/onboarding?source=homepage"
     );
-
-    await expect(page.getByRole("heading", { name: "You hire the AI. You keep the work." }))
-      .toBeVisible();
-    await expect(page.locator("#hero").getByText("Start in Claude. Finish in ChatGPT."))
-      .toBeVisible();
   });
 
-  test("pricing is plan intent, not checkout", async ({ page }) => {
-    await page.goto("/#pricing");
+  test("homepage removes old pricing and video surfaces", async ({ page }) => {
+    await page.goto("/");
 
-    await expect(page.getByRole("heading", { name: "Choose the starting shape." }))
-      .toBeVisible();
-    const pricing = page.locator("#pricing");
-
-    await expect(pricing.getByRole("heading", { name: "Principal", exact: true }))
-      .toBeVisible();
-    await expect(pricing.getByRole("heading", { name: "Team", exact: true })).toBeVisible();
-    await expect(pricing.getByRole("heading", { name: "Enterprise", exact: true }))
-      .toBeVisible();
-    await expect(pricing.getByText("Plan selection is intent, not checkout.")).toBeVisible();
+    await expect(page.locator("iframe")).toHaveCount(0);
+    await expect(page.getByText("Simple pricing")).toHaveCount(0);
+    await expect(page.getByText("$19")).toHaveCount(0);
     await expect(page.getByText("€3.99")).toHaveCount(0);
     await expect(page.getByText("7-day free trial")).toHaveCount(0);
+  });
 
-    const pricingStarts = page.locator("#pricing a", { hasText: "Start Now" });
-    const count = await pricingStarts.count();
-    expect(count).toBe(3);
+  test("proof mock renders Done and Next rows", async ({ page }) => {
+    await page.goto("/");
 
-    for (let index = 0; index < count; index += 1) {
-      await expect(pricingStarts.nth(index)).toHaveAttribute(
-        "href",
-        "https://dash.heystax.ai/onboarding?source=homepage"
-      );
-    }
+    await expect(page.getByText("Done while you slept. Decisions when you arrive."))
+      .toBeVisible();
+    await expect(page.getByText("@scribe drafted reply to solicitor")).toBeVisible();
+    await expect(page.getByText("@notify sent Sprint 7 update to John")).toBeVisible();
+    await expect(page.getByText("Lock SKU naming decision")).toBeVisible();
+    await expect(page.getByText("Approve scribe's draft to solicitor")).toBeVisible();
+    await expect(page.getByText("Yours")).toBeVisible();
+  });
+
+  test("technical and close sections match the spec", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByText('hey "draft update to @rob on Claim Alert sprint"'))
+      .toBeVisible();
+    await expect(
+      page.getByText("Start in Claude. Finish in ChatGPT. Same stax. Same information.")
+    ).toBeVisible();
+    await expect(page.getByText("GYST cohort one")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ten operators. By application." }))
+      .toBeVisible();
+    await expect(page.getByRole("link", { name: "Apply" })).toHaveAttribute(
+      "href",
+      "https://dash.heystax.ai/onboarding?source=homepage"
+    );
+  });
+
+  test("mobile layout stacks and keeps CTA buttons full width", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 900 });
+    await page.goto("/");
+
+    const startNow = page.locator("#hero a", { hasText: "Start Now" });
+    const box = await startNow.boundingBox();
+    expect(box).toBeTruthy();
+    expect(box!.width).toBeGreaterThan(300);
+
+    await expect(page.getByText("Typed work graph")).toBeVisible();
+    await expect(page.getByText("Cross-surface motion")).toBeVisible();
+    await expect(page.getByText("Agents as peers")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Rebuilds the HeyStax homepage with the new agent-aware marketing structure and proof mock.
- Removes homepage pricing and the old YouTube embed, moving pricing access to a /pricing placeholder.
- Narrows navigation and updates homepage metadata for the new positioning.

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Test
- [ ] CI

## Related issues
Refs #583

## Contract compliance
- Updated docs/contracts/feature_no_payment_signup_583.yml for the homepage rebuild.
- Updated docs/contracts/feature_architecture.yml CTA scope to the new homepage/pricing routes.
- Passed: npm test -- src/__tests__/contracts/no_payment_signup_583_contract.test.ts --runInBand

## Test plan
- Passed: npm test -- src/__tests__/contracts/no_payment_signup_583_contract.test.ts --runInBand
- Passed: npm run build
- Passed: npx playwright test tests/e2e/journey_no_payment_signup_583.spec.ts tests/e2e/journey_homepage_video.spec.ts --project=chromium

## Screenshots
- Verified locally and with Playwright at 390px mobile viewport.