### PR TITLE
fix(homepage): align signup close and hero video (#583)

### DIFF
--- a/docs/contracts/feature_no_payment_signup_583.yml
+++ b/docs/contracts/feature_no_payment_signup_583.yml
@@ -20,8 +20,8 @@ rules:
         - "src/app/pricing/page.tsx"
 
     - id: WEB-NPS-003
-      title: "Homepage proof mock replaces the old video"
-      requirement: "The homepage must not render the YouTube product embed. It must render the Done/Next proof rows from the rebuild spec."
+      title: "Homepage hero includes product video and proof mock"
+      requirement: "The homepage must render the YouTube product embed under the hero H2 and render the Done/Next proof rows from the rebuild spec."
       scope:
         - "src/app/page.tsx"
 
@@ -39,8 +39,8 @@ rules:
 
 acceptance:
   - "Hero Start Now opens Dash onboarding with source=homepage."
-  - "Homepage has no price copy and no YouTube iframe."
+  - "Homepage has no price copy and renders the product video under the hero H2."
   - "Proof mock shows Done rows, Next rows, and the Yours tag."
   - "Technical section contains the CLI code block and no technical heading."
-  - "Close section uses Apply, not Start Now."
+  - "Close section uses Start Now and routes to the signup plan flow."
   - "Footer links include Pricing, but homepage does not render pricing."

--- a/src/__tests__/contracts/no_payment_signup_583_contract.test.ts
+++ b/src/__tests__/contracts/no_payment_signup_583_contract.test.ts
@@ -40,10 +40,11 @@ describe("Contract: feature_no_payment_signup_583", () => {
     expect(page).not.toContain("Simple pricing");
   });
 
-  it("replaces the video with the Done and Next proof mock", () => {
+  it("renders the product video and the Done and Next proof mock", () => {
     const page = readSrc("app/page.tsx");
 
-    expect(page).not.toMatch(/iframe|youtube|youtube-nocookie/i);
+    expect(page).toContain("https://www.youtube-nocookie.com/embed/jcc-PsCdbM8");
+    expect(page).toContain('title="HeyStax product demo"');
     expect(page).toContain("Done while you slept. Decisions when you arrive.");
     expect(page).toContain("@scribe drafted reply to solicitor");
     expect(page).toContain("@notify sent Sprint 7 update to John");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,6 +92,17 @@ export default function Home() {
             Multiple projects, work and home. Your AI remembers none of them.
             HeyStax: All of them.
           </p>
+          <div className="mx-auto mt-10 max-w-4xl">
+            <div className="aspect-video w-full overflow-hidden rounded-[1.5rem] border border-charcoal/10 bg-charcoal/5 shadow-xl shadow-charcoal/10">
+              <iframe
+                className="h-full w-full"
+                src="https://www.youtube-nocookie.com/embed/jcc-PsCdbM8"
+                title="HeyStax product demo"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          </div>
           <p className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-warm-gray">
             HeyStax is the knowledge graph you own. Agents are peers coordinating
             your next move with you and your team. They know your projects, your
@@ -245,20 +256,18 @@ hey done 2`}</code>
       </section>
 
       <section className="border-t border-charcoal/10 bg-cream px-4 py-24 text-center sm:px-6 lg:px-8">
-        <p className="text-sm tracking-[0.22em] text-warm-gray">
-          GYST cohort one
-        </p>
         <h2 className="mx-auto mt-5 max-w-3xl font-heading text-5xl font-black leading-tight text-charcoal md:text-6xl">
-          Ten operators. By application.
+          Start with the work.
         </h2>
         <p className="mx-auto mt-6 max-w-md text-lg leading-relaxed text-warm-gray">
-          Three months free Pro. Personal onboarding. Real work, in real time.
+          Bring one project, one goal, and the people around it. HeyStax gives
+          the work somewhere to live.
         </p>
         <a
           href={DASH_ONBOARDING_URL}
           className="mobile-full-cta mt-10 inline-flex items-center justify-center rounded-full bg-amber px-8 py-4 text-lg font-semibold text-white shadow-lg transition-colors hover:bg-terracotta"
         >
-          Apply
+          Start Now
         </a>
       </section>
     </>

--- a/tests/e2e/journey_homepage_video.spec.ts
+++ b/tests/e2e/journey_homepage_video.spec.ts
@@ -1,17 +1,22 @@
 /**
- * The homepage rebuild explicitly removes the YouTube embed.
+ * Verifies the homepage product video is embedded below the hero H2.
  *
  * Run with: npm run test:e2e tests/e2e/journey_homepage_video.spec.ts
  */
 
 import { expect, test } from "@playwright/test";
 
-test.describe("homepage media removal", () => {
-  test("homepage does not render the old YouTube embed", async ({ page }) => {
+test.describe("homepage product video", () => {
+  test("hero renders the privacy-preserving product video embed", async ({ page }) => {
     await page.goto("/");
 
-    await expect(page.locator("iframe")).toHaveCount(0);
-    await expect(page.getByText("Done while you slept. Decisions when you arrive."))
-      .toBeVisible();
+    const iframe = page.locator("#hero iframe");
+    await expect(iframe).toHaveCount(1);
+    await expect(iframe).toBeVisible();
+    await expect(iframe).toHaveAttribute(
+      "src",
+      "https://www.youtube-nocookie.com/embed/jcc-PsCdbM8"
+    );
+    await expect(iframe).toHaveAttribute("title", "HeyStax product demo");
   });
 });

--- a/tests/e2e/journey_no_payment_signup_583.spec.ts
+++ b/tests/e2e/journey_no_payment_signup_583.spec.ts
@@ -29,10 +29,15 @@ test.describe("homepage rebuild signup handoff (#583)", () => {
     );
   });
 
-  test("homepage removes old pricing and video surfaces", async ({ page }) => {
+  test("homepage removes old pricing and restores the hero video", async ({ page }) => {
     await page.goto("/");
 
-    await expect(page.locator("iframe")).toHaveCount(0);
+    const heroVideo = page.locator("#hero iframe");
+    await expect(heroVideo).toHaveCount(1);
+    await expect(heroVideo).toHaveAttribute(
+      "src",
+      "https://www.youtube-nocookie.com/embed/jcc-PsCdbM8"
+    );
     await expect(page.getByText("Simple pricing")).toHaveCount(0);
     await expect(page.getByText("$19")).toHaveCount(0);
     await expect(page.getByText("€3.99")).toHaveCount(0);
@@ -59,10 +64,11 @@ test.describe("homepage rebuild signup handoff (#583)", () => {
     await expect(
       page.getByText("Start in Claude. Finish in ChatGPT. Same stax. Same information.")
     ).toBeVisible();
-    await expect(page.getByText("GYST cohort one")).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Ten operators. By application." }))
+    await expect(page.getByRole("heading", { name: "Start with the work." }))
       .toBeVisible();
-    await expect(page.getByRole("link", { name: "Apply" })).toHaveAttribute(
+    await expect(page.getByText("Bring one project, one goal, and the people around it."))
+      .toBeVisible();
+    await expect(page.locator("section").last().getByRole("link", { name: "Start Now" })).toHaveAttribute(
       "href",
       "https://dash.heystax.ai/onboarding?source=homepage"
     );


### PR DESCRIPTION
## Summary
- Changes the homepage close CTA from Apply to Start Now so users go into the signup plan flow.
- Restores the product video under the hero H2 using the privacy-preserving YouTube embed.
- Updates #583 contract and E2E coverage for the final CTA and hero video behavior.

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Test
- [ ] CI

## Related issues
Refs #583

## Contract compliance
- Updated docs/contracts/feature_no_payment_signup_583.yml for hero video and Start Now close CTA.
- Passed: npm test -- src/__tests__/contracts/no_payment_signup_583_contract.test.ts --runInBand

## Test plan
- Passed: npm test -- src/__tests__/contracts/no_payment_signup_583_contract.test.ts --runInBand
- Passed: npm run build
- Passed: npx playwright test tests/e2e/journey_no_payment_signup_583.spec.ts tests/e2e/journey_homepage_video.spec.ts --project=chromium

## Screenshots
- Verified locally at http://127.0.0.1:3001/ and with Playwright.